### PR TITLE
Update SparkpostTransport.php to support reply-to

### DIFF
--- a/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
+++ b/app/bundles/EmailBundle/Swiftmailer/Transport/SparkpostTransport.php
@@ -226,14 +226,6 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
             $recipients[] = $recipient;
         }
 
-        if (isset($message['replyTo'])) {
-            $headers['Reply-To'] = (!empty($message['replyTo']['name']))
-                ?
-                sprintf('%s <%s>', $message['replyTo']['email'], $message['replyTo']['name'])
-                :
-                $message['replyTo']['email'];
-        }
-
         $content = [
             'from' => (!empty($message['from']['name'])) ? $message['from']['name'].' <'.$message['from']['email'].'>'
                 : $message['from']['email'],
@@ -248,7 +240,15 @@ class SparkpostTransport extends AbstractTokenArrayTransport implements \Swift_T
         if (!empty($message['text'])) {
             $content['text'] = $message['text'];
         }
-
+        
+        if (isset($message['replyTo'])) {
+            $content['reply_to'] = (!empty($message['replyTo']['name']))
+                ?
+                sprintf('%s <%s>', $message['replyTo']['email'], $message['replyTo']['name'])
+                :
+                $message['replyTo']['email'];
+        }
+        
         $sparkPostMessage = [
             'content'    => $content,
             'recipients' => $recipients,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Yes |
| New feature? | No |
| Related user documentation PR URL |  |
| Related developer documentation PR URL |  |
| Issues addressed (#s or URLs) | #2853 |
| BC breaks? |  |
| Deprecations? |  |
#### Description:

Fixed bug in Sparkpost transport which meant reply-to (if applied for an email) was not set on emails sent via Sparkpost API.
Sparkpost transport set reply-to in headers part, instead of using reply_to key in the content part of the object sent to Sparkpost api.
#### Steps to test this PR:
1. Configure emails to be sent with Sparkpost
2. Create email with Reply-To set under Edit->Advanced
3. Send email and check if it has a reply-to address
#### Steps to reproduce the bug:
1. Configure emails to be sent with Sparkpost
2. Create email with Reply-To set under Edit->Advanced
3. Send email and see it has no reply-to address
#### List deprecations along with the new alternative:
1. 
2. 
#### List backwards compatibility breaks:
1. 
2. 
   Sparkpost API does not support reply-to via sparkPostMessage headers. Instead reply_to key in content must be used.
